### PR TITLE
Add alignment section

### DIFF
--- a/bib/references.bib
+++ b/bib/references.bib
@@ -535,22 +535,6 @@
   month={Nov}
 }
 
-@article{Lee_2018,
-  title={AltHapAlignR: improved accuracy of RNA-seq analyses through the use of alternative haplotypes},
-  volume={34},
-  ISSN={1460-2059},
-  url={http://dx.doi.org/10.1093/bioinformatics/bty125},
-  DOI={10.1093/bioinformatics/bty125},
-  number={14},
-  journal={Bioinformatics},
-  publisher={Oxford University Press (OUP)},
-  author={Lee, Wanseon and Plant, Katharine and Humburg, Peter and Knight, Julian C},
-  editor={Wren, JonathanEditor},
-  year={2018},
-  month={Mar},
-  pages={2401–2408}
-}
-
 @article{Liu_2018,
   title={iMapSplice: Alleviating reference bias through personalized RNA-seq alignment},
   volume={13},
@@ -709,3 +693,160 @@
   note    = {bioRxiv},
   doi     = {10.1101/305268}
 }
+
+@article{Lee_2002,
+  doi = {10.1093/bioinformatics/18.3.452},
+  url = {https://doi.org/10.1093/bioinformatics/18.3.452},
+  year = {2002},
+  month = mar,
+  publisher = {Oxford University Press ({OUP})},
+  volume = {18},
+  number = {3},
+  pages = {452--464},
+  author = {Christopher Lee and Catherine Grasso and Mark F. Sharlow},
+  title = {Multiple sequence alignment using partial order graphs},
+  journal = {Bioinformatics}
+}
+
+@article{Grasso_2004,
+  doi = {10.1093/bioinformatics/bth126},
+  url = {https://doi.org/10.1093/bioinformatics/bth126},
+  year = {2004},
+  month = feb,
+  publisher = {Oxford University Press ({OUP})},
+  volume = {20},
+  number = {10},
+  pages = {1546--1556},
+  author = {Catherine Grasso and Christopher Lee},
+  title = {Combining partial order alignment and progressive multiple sequence alignment increases alignment speed and scalability to very large alignment problems},
+  journal = {Bioinformatics}
+}
+
+@article{Kavya_2019,
+  doi = {10.1089/cmb.2017.0264},
+  url = {https://doi.org/10.1089/cmb.2017.0264},
+  year = {2019},
+  month = jan,
+  publisher = {Mary Ann Liebert Inc},
+  volume = {26},
+  number = {1},
+  pages = {53--67},
+  author = {Vaddadi Naga Sai Kavya and Kshitij Tayal and Rajgopal Srinivasan and Naveen Sivadasan},
+  title = {Sequence Alignment on Directed Graphs},
+  journal = {Journal of Computational Biology}
+}
+
+
+@article{Rautiainen_2017,
+  doi = {10.1101/216127},
+  url = {https://doi.org/10.1101/216127},
+  year = {2017},
+  month = nov,
+  publisher = {Cold Spring Harbor Laboratory},
+  author = {Mikko Rautiainen and Tobias Marschall},
+  title = {Aligning sequences to general graphs in {O(V + mE)} time}
+}
+
+@article{Rautiainen_2019,
+  doi = {10.1093/bioinformatics/btz162},
+  url = {https://doi.org/10.1093/bioinformatics/btz162},
+  year = {2019},
+  month = mar,
+  publisher = {Oxford University Press ({OUP})},
+  volume = {35},
+  number = {19},
+  pages = {3599--3607},
+  author = {Mikko Rautiainen and Veli M\"{a}kinen and Tobias Marschall},
+  editor = {Inanc Birol},
+  title = {Bit-parallel sequence-to-graph alignment},
+  journal = {Bioinformatics}
+}
+
+@article{Antipov_2015,
+  doi = {10.1093/bioinformatics/btv688},
+  url = {https://doi.org/10.1093/bioinformatics/btv688},
+  year = {2015},
+  month = nov,
+  publisher = {Oxford University Press ({OUP})},
+  volume = {32},
+  number = {7},
+  pages = {1009--1015},
+  author = {Dmitry Antipov and Anton Korobeynikov and Jeffrey S. McLean and Pavel A. Pevzner},
+  title = {{hybridSPAdes}: an algorithm for hybrid assembly of short and long reads},
+  journal = {Bioinformatics}
+}
+
+@article{Jain_2019a,
+  doi = {10.1101/522912},
+  url = {https://doi.org/10.1101/522912},
+  year = {2019},
+  month = jan,
+  publisher = {Cold Spring Harbor Laboratory},
+  author = {Chirag Jain and Haowen Zhang and Yu Gao and Srinivas Aluru},
+  title = {On the Complexity of Sequence to Graph Alignment}
+}
+
+@inproceedings{Jain_2019b,
+  doi = {10.1109/ipdps.2019.00055},
+  url = {https://doi.org/10.1109/ipdps.2019.00055},
+  year = {2019},
+  month = may,
+  publisher = {{IEEE}},
+  author = {Chirag Jain and Sanchit Misra and Haowen Zhang and Alexander Dilthey and Srinivas Aluru},
+  title = {Accelerating Sequence Alignment to Graphs},
+  booktitle = {2019 {IEEE} International Parallel and Distributed Processing Symposium ({IPDPS})}
+}
+
+@article{Equi_2019,
+  doi = {10.4230/LIPICS.ICALP.2019.55},
+  url = {http://drops.dagstuhl.de/opus/volltexte/2019/10631/},
+  author = {Equi,  Massimo and Grossi,  Roberto and M\"{a}kinen,  Veli and Tomescu,  Alexandru I.},
+  keywords = {Computer Science,  000 Computer science,  knowledge,  general works},
+  language = {en},
+  title = {On the Complexity of String Matching for Graphs},
+  publisher = {Schloss Dagstuhl - Leibniz-Zentrum fuer Informatik GmbH,  Wadern/Saarbruecken,  Germany},
+  year = {2019}
+}
+
+@article{Myers_1989,
+  doi = {10.1016/s0092-8240(89)80046-1},
+  url = {https://doi.org/10.1016/s0092-8240(89)80046-1},
+  year = {1989},
+  publisher = {Springer Nature},
+  volume = {51},
+  number = {1},
+  pages = {5--37},
+  author = {Eugene Myers and Webb Miller},
+  title = {Approximate matching of regular expressions},
+  journal = {Bulletin of Mathematical Biology}
+}
+
+@incollection{Amir_1997,
+  doi = {10.1007/3-540-63307-3_56},
+  url = {https://doi.org/10.1007/3-540-63307-3_56},
+  year = {1997},
+  publisher = {Springer Berlin Heidelberg},
+  pages = {160--173},
+  author = {Amihood Amir and Moshe Lewenstein and Noa Lewenstein},
+  title = {Pattern matching in hypertext},
+  booktitle = {Lecture Notes in Computer Science}
+}
+
+@article{Smith_1981,
+  title={Comparison of biosequences},
+  author={Smith, Temple F and Waterman, Michael S},
+  journal={Advances in Applied Mathematics},
+  volume={2},
+  number={4},
+  pages={482--489},
+  year={1981},
+  publisher={Elsevier}
+}
+
+@misc{Suzuki_2018,
+    author       = {Hajime Suzuke},
+    title        = {{dozeu}},
+    year         = {2018},
+    url          = {https://github.com/ocxtal/dozeu}
+ }
+

--- a/sections/relating.tex
+++ b/sections/relating.tex
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 % Heading 3
 \section{Relating new information to the model}
 This is dummy text. This is dummy text. This is dummy text. This is dummy text. 
@@ -92,7 +91,27 @@ Figure~\ref{fig:visualization} provides a visual overview of the visualization m
 % Jordan
 
 \subsection{Graph alignment algorithms}
-% Jordan
+Often, genomic sequence data can only be interpreted in the context of other sequences. 
+For this reason, sequence comparison is at the core of many genomic analyses, and sequence alignment is the essential method for doing so. 
+However, classic alignment algorithms like Smith-Waterman\cite{Smith_1981} do not directly apply to sequence graphs. 
+Accordingly, the increasing prominence of variation graph methods has been fueled by fundamental algorithmic research in graph alignment, and it has also spurred further research.
+
+The trend in the graph alignment research is toward greater generality and faster run time. 
+The generality comes in two main forms. 
+First, algorithms apply to increasingly general classes of graphs. 
+The foundational genomic sequence graph alignment algorithms applied only to graphs without cycles\cite{Lee_2002, Grasso_2004}. 
+More recent research has discovered algorithms that align to graphs with any shape\cite{Antipov_2015,Rautiainen_2017,Jain_2019a}. 
+Second, graph alignment researchers have developed algorithms that use increasingly general scoring functions. 
+Some earlier algorithms require restricted scoring functions to achieve efficiency\cite{Rautiainen_2017}, but recent contributions have used the less restricted scoring functions that are required to produce biologically meaningful alignments in many contexts\cite{Jain_2019a}.
+
+Graph alignment research also has improved the algorithms' run time. 
+The first algorithms only required restricted graphs in order to run at comparable speed to non-graph sequence alignment algorithms, or else simply ran slower on general graphs\cite{Lee_2002, Kavya_2019}. 
+It has now been shown that graph alignment can run at the same speed as non-graph alignment (in the computer scientist's sense of ``Big-O'' asymptotics), which is believed to be essentially optimal\cite{Jain_2019a,Equi_2019}. 
+Many of the advances in this space came from rediscovering analogs to the graph alignment problem in the related areas of regular expressions and hypertext\cite{Myers_1989,Amir_1997}. 
+In addition to these theoretical results, researchers have also developed modified algorithms that run quickly the practical context of real-world computer architectures\cite{Suzuki_2018,Rautiainen_2019,Jain_2019b}.
+
+From a practical standpoint, the primary benefit of this research in alignment algorithms has been in aiding the design of mapping tools. 
+Graph alignment algorithms are a central component of the graph mapping tools described below.
 
 \subsection{Variation graph mappers}
 There are several mapping algorithms for variation graphs which extend concepts from linear mapping algorithms into a graph space.


### PR DESCRIPTION
I added a draft section on graph alignment, and the associated bibtex references. I didn't put in context mapping, thinking that might actually fit better in the section on genome graph structure.