### PR TITLE
added two more references

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ https://doi.org/10.1093/bioinformatics/btu756
 
 ## Finding structures in pangenome graphs
 
-Bubbles (various)
-...
+Bubbles (various) 
+Bubbleparse (2013) https://journals.plos.org/plosone/article/comments?id=10.1371/journal.pone.0060058
 
 Superbubbles (various)
 ...
@@ -357,6 +357,12 @@ GraphAligner (preprint 2019) -- alread mentioned as aligner above
 https://doi.org/10.1101/810812
 
 ## Variant calling / Genotyping
+
+Cortex (2012)
+ https://www.nature.com/articles/ng.1028
+
+Bubbleparse (2013)
+https://journals.plos.org/plosone/article/comments?id=10.1371/journal.pone.0060058
 
 1000GP phase 3 paper (2015) -- graph based genotyping process described in supplement
 https://doi.org/10.1038/nature15393 

--- a/bib/references.bib
+++ b/bib/references.bib
@@ -2026,3 +2026,15 @@
   month={Aug},
   pages={360–363}
 }
+
+
+@article{Leggett_2013,
+	title={Identifying and classifying trait linked polymorphisms in non-reference species by walking coloured de Bruijn graphs},
+	author={Leggett, Richard M and Ramirez-Gonzalez, Ricardo H and Verweij, Walter and Kawashima, Cintia G and Iqbal, Zamin and Jones, Jonathan DG and Caccamo, Mario and MacLean, Daniel},
+	journal={PLoS One},
+	volume={8},
+	number={3},
+	pages={e60058},
+	year={2013},
+	publisher={Public Library of Science}
+}

--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -57,9 +57,9 @@ This can, in turn, cause variant calling errors.
 Second, missing variation in the reference can cause base-level alignment artifacts.
 Mapping and aligning to pangenome models provides the opportunity to mitigate these biases.
 
-\todo[inline] {JE: maybe also mention Cortex? They mainly focus on calling variants but also describe how to genotype them. Bubbleparse seems to be another variant caller.}
-% Cortex constructs a colored de Bruijn graph which can include data of multiple samples and additional sources of sequence information, like a reference sequence or known alleles \cite{Iqbal_2012}. Variants are called from the graph by identifying bubble structures in the graph, and can be genotyped based on a samples coverage of allele specific kmers. The approach efficiently handles simultaneous analysis of multiple genomes and enables accurate variant detection in a reference-free manner.
 
+In order to call variants, approaches relying on de Bruijn graphs have been suggested. Cortex  \cite{Iqbal_2012} constructs a colored de Bruijn graph which can include data of multiple samples and additional sources of sequence information, like a reference genome or known alleles. Variants are detected by identifying bubble structures in the graph and  genotyped based on the samples' coverage of allele specific kmers. The approach efficiently handles simultaneous analysis of multiple genomes and enables accurate variant detection in a reference-free manner.
+Bubbleparse \cite{Leggett_2013} extends the model implemented in Cortex and aims at improving SNP discovery. Candidate variants are produced by a bubble calling algorithm and a heuristic is presented which uses a classification and ranking system to controls the specificity of reported SNP calls \cite{Leggett_2013}.
 
 One strategy for genotyping small variants consists of using graphs of known variation in local regions to realign reads that were mapped to a linear reference.
 This approach was pioneered in the 1000 Genomes Project by the GLIA software.

--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -28,7 +28,7 @@ It is no longer necessary, or even advisable, to restrict inference to the sampl
 Increasingly large databases of variation are publicly available to guide future analyses.
 The benefits of multi-sample calling can now be brought to bear even on individual samples.
 
-In pangenomics, it is useful distinguish between \emph{variant calling} and \emph{genotyping}.
+In pangenomics, it is useful to distinguish between \emph{variant calling} and \emph{genotyping}.
 Variant calling consists of detecting variation that is yet unobserved, whereas genotyping involves determining whether a previously observed variant is present in a new sample.
 Intuitively, pangenomic methods should provide greater benefit to genotyping, and indeed most existing tools emphasize it over variant calling.
 %TODO: i thought i had another sentence here, but i can't remember it...
@@ -56,6 +56,10 @@ First, structural variants and regions of dense variation can confound read mapp
 This can, in turn, cause variant calling errors.
 Second, missing variation in the reference can cause base-level alignment artifacts.
 Mapping and aligning to pangenome models provides the opportunity to mitigate these biases.
+
+\todo[inline] {JE: maybe also mention Cortex? They mainly focus on calling variants but also describe how to genotype them. Bubbleparse seems to be another variant caller.}
+% Cortex constructs a colored de Bruijn graph which can include data of multiple samples and additional sources of sequence information, like a reference sequence or known alleles \cite{Iqbal_2012}. Variants are called from the graph by identifying bubble structures in the graph, and can be genotyped based on a samples coverage of allele specific kmers. The approach efficiently handles simultaneous analysis of multiple genomes and enables accurate variant detection in a reference-free manner.
+
 
 One strategy for genotyping small variants consists of using graphs of known variation in local regions to realign reads that were mapped to a linear reference.
 This approach was pioneered in the 1000 Genomes Project by the GLIA software.
@@ -159,7 +163,7 @@ Paragraph was shown to outperform similar methods that rely on linear references
 
 
 VG's SV genotyper can be run on any genome graph that contains embedded paths, which are required as the coordinate space for VCF output \cite{hickey2019genotyping}.
-Unlike Paragraph, VG operates on alignments that were produced against against the graph without any intermediate use of a linear reference.
+Unlike Paragraph, VG operates on alignments that were produced against the graph without any intermediate use of a linear reference.
 It uses the snarl decomposition \cite{paten2018superbubbles} to identify sites of variation in the graph, and derives haplotypes using read support.
 It was shown to be much more accurate than linear reference-based approaches, and was also evaluated on graphs derived from alignments of assemblies.
 


### PR DESCRIPTION
There are some variant detection algorithms described in the Cortex and Bubbleparse papers (I added links to the Readme) that rely on colored de Bruijn graphs. They might be interesting to mention in the variant calling section. 