### PR TITLE
Reorganize transcriptomics section

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -34,7 +34,7 @@
 \begin{document}
 
 \newcommand{\shorttitle}{Precision pangenomics}
-\newcommand{\firstauthorlastname}{Garrison}
+\newcommand{\firstauthorlastname}{Eizenga}
 
 % Page header
 \markboth{\firstauthorlastname\ et al.}{\shorttitle}
@@ -45,24 +45,24 @@
 
 %Authors, affiliations address.
 \author{%
-  Erik \firstauthorlastname$^{*1}$,
-  Xian Chang$^1$,
-  Glenn Hickey$^1$,
-  Jean Monlong$^1$,
-  Adam Novak$^1$,
-  Robin Rounthwaite$^1$,
-  Benedict Paten$^1$,
+  Jordan \firstauthorlastname${}$,
+  Simon Heumos$^2$,
   Jonas Sibbesen$^1$,
-  Jouni Sir\'{e}n$^1$,
-  Josiah D Seaman$^2$$^3$,
-  Simon Heumos$^4$,
+  Glenn Hickey$^1$,
+  Adam Novak$^1$,
+  Xian Chang$^1$,
+  Jean Monlong$^1$,
+  Robin Rounthwaite$^1$,
+  Josiah D Seaman$^3$$^4$,
   Mikko Rautiainen$^5$$^6$$^7$,
-  and Jordan Eizenga$^1$
+  Jouni Sir\'{e}n$^1$,
+  Benedict Paten$^1$,
+  and Erik Garrison$^{*1}$
 %\affil{$^1$Genomics Institute, University of California Santa Cruz, Santa Cruz, CA, USA, 95064;
 \affil{$^1$Genomics Institute, University of California Santa Cruz, Santa Cruz, CA, USA, 95064}
-\affil{$^2$Royal Botanic Gardens Kew, Richmond, UK, TW9 3AB}
-\affil{$^3$Queen Mary University of London, London, UK, E1 4NS}
-\affil{$^4$Quantitative Biology Center, University of Tübingen, Tübingen, Germany, 72076}
+\affil{$^2$Quantitative Biology Center, University of Tübingen, Tübingen, Germany, 72076}
+\affil{$^3$Royal Botanic Gardens Kew, Richmond, UK, TW9 3AB}
+\affil{$^4$Queen Mary University of London, London, UK, E1 4NS}
 \affil{$^5$Center for Bioinformatics, Saarland University, Saarbr\"{u}cken, Germany, 66123}
 \affil{$^6$Max Planck Institute for Informatics, Saarbr\"{u}cken, Germany, 66123}
 \affil{$^7$Saarbr\"{u}cken Graduate School for Computer Science, Saarbr\"{u}cken, Germany, 66123}

--- a/main.tex
+++ b/main.tex
@@ -45,7 +45,7 @@
 
 %Authors, affiliations address.
 \author{%
-  Jordan \firstauthorlastname${}$,
+  Jordan \firstauthorlastname$^1$,
   Simon Heumos$^2$,
   Jonas Sibbesen$^1$,
   Glenn Hickey$^1$,
@@ -53,8 +53,8 @@
   Xian Chang$^1$,
   Jean Monlong$^1$,
   Robin Rounthwaite$^1$,
-  Josiah D Seaman$^3$$^4$,
-  Mikko Rautiainen$^5$$^6$$^7$,
+  Josiah D Seaman$^{3,4}$,
+  Mikko Rautiainen$^{5,6,7}$,
   Jouni Sir\'{e}n$^1$,
   Benedict Paten$^1$,
   and Erik Garrison$^{*1}$

--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -182,56 +182,57 @@ Furthermore, we have shown that we can detect and phase structural variants.
 CHiP-seq data, reads that bind to specific transcription factors, can be mapped back to the reference genome in order to locate binding sites.
  
 Graph Peak Caller is based on \texttt{vg} and is the first tool to use a genome graph for this process \cite{Grytten_2019}.
-It was shown to find binding sites more enriched for known DNA binding motifs than linear methods on \emph{A.
-thaliana}.
+It was shown to find binding sites more enriched for known DNA binding motifs than linear methods on \emph{A. thaliana}.
 It was also applied to human data to discover novel sites for enhancers in the human genome \cite{groza2019personalized}. 
 
 \todo[inline]{Do we need a real epigenomics section about DNA base or histone modification?}
 
 \subsection{Transcriptomics}
 
-Attempts to use genome graphs to analyze transcriptomic sequencing data have generally received less attention than similar experiments with whole genome sequencing data.
-However, when estimating allele-specific expression (ASE) reference bias is an important issue that needs to be addressed \cite{Degner2009-vw,Castel2015-ef}.
-ASE analysis estimates the expression levels of genes or transcripts on each allele separately, by simply put comparing the number of RNA sequencing (RNA-seq) reads mapped to the two different alleles of heterozygous variants.
-A mapping bias in favor of one of the alleles can therefore result in a false-positive difference in expression between the alleles.
-Variant-aware methods, including those based on genome graphs, allow for the sequence difference between the two alleles to be considered during mapping thus reducing reference bias.
+Some transcriptomic analyses are strongly affected by reference bias.
+Chief among these is allele-specific expression (ASE) \cite{Degner2009-vw,Castel2015-ef}.
+ASE analysis estimates the expression levels of genes or transcripts on each allele separately by comparing the number of RNA sequencing (RNA-seq) reads mapped to the two different alleles of heterozygous variants.
+A mapping bias in favor of one of the alleles can therefore create illusory differences in expression between the alleles.
 
 The simplest approach to using variation data in mapping involves creating a personalized diploid genome or transcriptome, which is then used as the reference for a standard linear mapping method \cite{Turro2011-op,Rozowsky_2011,Bray_2016,Raghupathy2018-sd}.
 Methods using this approach have been shown to reduce reference bias and improve estimation of ASE, relative to traditional single reference genome methods, but they are limited by requiring phased haplotypes for the individuals under study.
+Variant-aware mappers remove this necessity.
+For example, ASElux \cite{Miao2018-ps} and GSNAP \cite{Castel2015-ef} were both shown to reduce reference bias in ASE quantification.
+ASElux is significantly faster than GSNAP, but GSNAP reduces reference bias slightly more \cite{Miao2018-ps}.
 
-Proper variant-aware mapping methods, on the other hand, do not require that the variants are phased beforehand.
-GSNAP was the first variant- and splicing-aware mapping method developed for RNA-seq data \cite{Wu2010-hv}\todo{JAS: We might want to add GSNAP introduction to the model section since it is general and also works for WGS}.
-It uses a kmer-based approach where both the genome and a set of SNVs are indexed using hash tables.
-The current version uses a suffix array in addition to the hash table.
-GSNAP is still competitive with regards to mapping accuracy, but it is generally much slower than contemporary mapping methods.
-Although not demonstrated in the initial publication, GSNAP does reduce reference bias around SNVs \cite{Castel2015-ef}.
+%GSNAP was the first variant- and splicing-aware mapping method developed for RNA-seq data \cite{Wu2010-hv}\todo{JAS: We might want to add GSNAP introduction to the model section since it is general and also works for WGS}.
+%It uses a kmer-based approach where both the genome and a set of SNVs are indexed using hash tables.
+%The current version uses a suffix array in addition to the hash table.
+%GSNAP is still competitive with regards to mapping accuracy, but it is generally much slower than contemporary mapping methods.
+%Although not demonstrated in the initial publication, GSNAP does reduce reference bias around SNVs \cite{Castel2015-ef}.
+%
+%Another variant-aware method, ASElux, uses all heterozygous exonic SNVs in an individual to create a suffix array index of the alleles and their flanking sequences \cite{Miao2018-ps}. 
+%This index is used to filter read pairs that does not overlap any SNVs with up to 2 mismatches. 
+%The much smaller set of read pairs that pass this filter are then aligned to a different suffix array index consisting of exonic and intronic regions and pairs that align unique to a single gene are used for allele counting. 
+%ASElux achieves higher accuracy for ASE estimation compared to pipelines based on linear mappers and is significantly faster than GSNAP which reduces reference bias slightly more.
 
-Another variant-aware method, ASElux, uses all heterozygous exonic SNVs in an individual to create a suffix array index of the alleles and their flanking sequences \cite{Miao2018-ps}. 
-This index is used to filter read pairs that does not overlap any SNVs with up to 2 mismatches. 
-The much smaller set of read pairs that pass this filter are then aligned to a different suffix array index consisting of exonic and intronic regions and pairs that align unique to a single gene are used for allele counting. 
-ASElux achieves higher accuracy for ASE estimation compared to pipelines based on linear mappers and is significantly faster than GSNAP which reduces reference bias slightly more.
+%Similarly to ASElux, iMapSplice creates an index of SNV alleles and their flanking sequences \cite{Liu_2018}.
+%The sequences are indexed using enhanced suffix arrays and reads are mapped to both this index and the reference genome simultaneously.
+%The authors demonstrated that iMapSplice achieves higher mapping accuracy and lower reference bias compared to both a linear mapping method and HISAT2, another variant-aware method.
 
-Similarly to ASElux, iMapSplice creates an index of SNV alleles and their flanking sequences \cite{Liu_2018}.
-The sequences are indexed using enhanced suffix arrays and reads are mapped to both this index and the reference genome simultaneously.
-The authors demonstrated that iMapSplice achieves higher mapping accuracy and lower reference bias compared to both a linear mapping method and HISAT2, another variant-aware method.
+%GSNAP, ASElux and iMapSplice only support SNVs and are therefore not able to reduce reference bias around indels.
+%HISAT2 was the first genome graph based, non-SNV-variant-aware method for splicing-aware mapping of RNA-seq data \cite{Kim_2019}. 
+%This method can use SNVs, deletions of any length, and insertions up to 20~bp.
+%HISAT2 uses a combination of a hierarchical graph FM index and a repeat region index to map the sequencing reads to the genome graph (see Variation Graph Mapper section for more details).
+%Their benchmark only shows results for DNA sequencing data, but \citeauthor{Liu_2018} did show in their iMapSplice benchmark a reduction in reference bias for HISAT2 around SNVs using an older version.  
+%
+%Recently, the ability to create spliced variation graphs was added to the \texttt{vg} toolkit \cite{Garrison_2018}. 
+%In these variation graphs, known splice junctions are added as edges, similar to the addition of a deletion event, while transcripts are embedded as paths through the graph. 
+%This allows for existing algorithms in \texttt{vg} to also be used for variant-aware mapping of RNA-seq data. 
+%\texttt{vg} supports any type of variation, but its splicing-awareness is limited to only known splice junctions, and it does not support generating supplementary alignments.
+%Thus, reads that span a novel splice junction will only map partially.
 
-GSNAP, ASElux and iMapSplice only support SNVs and are therefore not able to reduce reference bias around indels.
-HISAT2 was the first genome graph based, non-SNV-variant-aware method for splicing-aware mapping of RNA-seq data \cite{Kim_2019}. 
-This method can use SNVs, deletions of any length, and insertions up to 20~bp.
-HISAT2 uses a combination of a hierarchical graph FM index and a repeat region index to map the sequencing reads to the genome graph (see Variation Graph Mapper section for more details).
-Their benchmark only shows results for DNA sequencing data, but \citeauthor{Liu_2018} did show in their iMapSplice benchmark a reduction in reference bias for HISAT2 around SNVs using an older version.  
-
-Recently, the ability to create spliced variation graphs was added to the \texttt{vg} toolkit \cite{Garrison_2018}. 
-In these variation graphs, known splice junctions are added as edges, similar to the addition of a deletion event, while transcripts are embedded as paths through the graph. 
-This allows for existing algorithms in \texttt{vg} to also be used for variant-aware mapping of RNA-seq data. 
-\texttt{vg} supports any type of variation, but its splicing-awareness is limited to only known splice junctions, and it does not support generating supplementary alignments.
-Thus, reads that span a novel splice junction will only map partially.
-
-As with whole genome DNA sequencing data, variation-aware analysis of RNA-seq data is important for getting accurate results in highly polymorphic regions, such as the HLA genes in the human major histocompatibility complex region. 
+Variation-aware analysis of RNA-seq data is important accurately analyzing highly polymorphic regions.
+As with variant calling, the case that has generated the most interest is the HLA genes in the human MHC. 
 AltHapAlignR and HLApers have both demonstrated improvements in the estimation of HLA gene/transcript expression as a result of comparing the reads against a collection of known HLA haplotypes, instead of using the linear reference \cite{Lee_2018,Aguiar2019-fy}.
 
-Leveraging variation even in the intronic regions can be helpful when analysing RNA-seq data. 
-Variation in these regions can disrupt existing splice-site motifs or create new ones, resulting in intron retention or novel splicing, respectively. 
+Even intronic variation can be helpful for analyzing RNA-seq data. 
+Intronic variation can disrupt existing splice-site motifs or create new ones, resulting in intron retention or novel splicing, respectively. 
 Since the presence or absence of canonical splice-site motifs is often used as a factor when scoring alignments across splice junctions, mappers which are aware of these changes to the motifs are able to give more accurate mapping results for reads that overlaps the modified splice-junctions. 
 Indeed, by using a personalized genome approach, \citeauthor{Stein_2015} were able to identify 506 personal splice junctions in 75 individuals, of which 437 were novel \cite{Stein_2015}.
 Even more novel junctions were later found in the same individuals by \citeauthor{Liu_2018} using iMapSplice \cite{Liu_2018}.

--- a/sections/relating.tex
+++ b/sections/relating.tex
@@ -476,6 +476,43 @@ GraphAligner & Variation graph or overlap graph & Long read & Fast \\ \hline
 
 % See also: https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-016-1103-9
 
+\subsection{Variation-aware transcriptomic mapping}
+
+Attempts to use pangenomic models to analyze transcriptomic sequencing data have generally received less attention than similar experiments with whole genome sequencing data.
+However, certain downstream applications also benefit from incorporating information on genomic variation.
+Due to presence of splicing, mapping transcriptomic reads typically requires specialized algorithms.
+Thus, variation-aware mappers for transcript reads have largely been developed in parallel to mappers for genomic reads, although there is some overlap.
+
+%Proper variant-aware mapping methods, on the other hand, do not require that the variants are phased beforehand.
+GSNAP was the first variant- and splicing-aware mapping method developed for RNA-seq data \cite{Wu2010-hv}%\todo{JAS: We might want to add GSNAP introduction to the model section since it is general and also works for WGS}.
+It uses a $k$-mer-based approach where both the genome and a set of SNVs are indexed using hash tables.
+The current version uses a suffix array in addition to the hash table.
+GSNAP is still competitive with regards to mapping accuracy, but it is generally much slower than contemporary mapping methods.
+Although not demonstrated in the initial publication, GSNAP does reduce reference bias around SNVs \cite{Castel2015-ef}.
+
+Another variant-aware method, ASElux, uses all heterozygous exonic SNVs in an individual to create a suffix array index of the alleles and their flanking sequences \cite{Miao2018-ps}. 
+This index is used to filter read pairs that does not overlap any SNVs with up to 2 mismatches. 
+The much smaller set of read pairs that pass this filter are then aligned to a different suffix array index consisting of exonic and intronic regions and pairs that align unique to a single gene are used for allele counting. 
+
+Similarly to ASElux, iMapSplice creates an index of SNV alleles and their flanking sequences \cite{Liu_2018}.
+The sequences are indexed using enhanced suffix arrays and reads are mapped to both this index and the reference genome simultaneously.
+The authors demonstrated that iMapSplice achieves higher mapping accuracy and lower reference bias compared to both a linear mapping method and HISAT2, another variant-aware method.
+
+GSNAP, ASElux and iMapSplice only support SNVs and are therefore not able to reduce reference bias around indels.
+HISAT2 was the first explicitly genome graph-based, non-SNV-variant-aware method for splicing-aware mapping of RNA-seq data \cite{Kim_2019}. 
+This method can use SNVs, deletions of any length, and insertions up to 20~bp.
+Its mapping algorithm for transcriptomic sequencing is the same as for genomic DNA (See above).
+In their benchmark for iMapSplice, \citeauthor{Liu_2018} showed a reduction in reference bias around SNVs for an early version of HISAT2. 
+
+Recently, the ability to create spliced variation graphs was added to VG \cite{Garrison_2018}. 
+In these variation graphs, known splice junctions are added as edges, similar to the addition of a deletion event, while transcripts are embedded as paths through the graph. 
+This allows for existing algorithms in \texttt{vg} to also be used for variant-aware mapping of RNA-seq data. 
+VG supports any type of variation, but its splicing-awareness is limited to only known splice junctions, and it does not support generating supplementary alignments.
+Thus, reads that span a novel splice junction will only map partially.
+
+%As with whole genome DNA sequencing data, variation-aware analysis of RNA-seq data is important for getting accurate results in highly polymorphic regions, such as the HLA genes in the human major histocompatibility complex region. 
+%AltHapAlignR and HLApers have both demonstrated improvements in the estimation of HLA gene/transcript expression as a result of comparing the reads against a collection of known HLA haplotypes, instead of using the linear reference \cite{Lee_2018,Aguiar2019-fy}.
+
 
 %\subsection{Non-graph population mapping tools}
 % Erik


### PR DESCRIPTION
I split the transcriptomics section into two: one on mapping, one on downstream applications. I also made myself first author and Erik last author. 

@jonassibbesen Could you review my changes and make sure they're still accurate?