### PR TITLE
Cut mapper refs

### DIFF
--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -17,16 +17,15 @@ The advent of pangenomics represents an opportunity to improve this methodology 
 These strategies can be coarsely divided into two umbrella approaches.
 First, known variation can inform inference by providing a statistical prior.
 Second, known variation can help applications avoid algorithmic artifacts that frustrate inference.
-Together, these advantages are helping pangenomics expand the limits of what variation current technology can detect and how accurately it can do so.
+%Together, these advantages are helping pangenomics expand the limits of what variation current technology can detect and how accurately it can do so.
 
 In many ways, the spiritual predecessors of pangenomic variant calling are multi-sample calling methods. 
 Many of these were developed alongside major population sequencing projects like the 1000 Genomes Project \cite{1000_2015}.
-They co-call variants on a group of samples in a single, shared inference process \cite{Li_2011,Garrison_2012}.
+They co-call variants on a group of samples in a single, shared inference process.
 The motivation for doing so mirrors the motivation for pangenomic variant calling: increased statistical power via a shared prior and reduced algorithmic bias.
 The main difference today is the abundance of data available.
-It is no longer necessary, or even advisable, to restrict inference to the samples obtained in one project.
-Increasingly large databases of variation are publicly available to guide future analyses.
-The benefits of multi-sample calling can now be brought to bear even on individual samples.
+It is no longer necessary to restrict inference to the samples from one project.
+With public databases of variation, the benefits of multi-sample calling can now be brought to bear even on individual samples.
 
 In pangenomics, it is useful to distinguish between \emph{variant calling} and \emph{genotyping}.
 Genotyping consists of determining whether a previously observed variant is present in a new sample, whereas variant calling involves detecting yet unobserved variation.

--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -54,8 +54,8 @@ Intuitively, pangenomic methods should provide greater benefit to genotyping, an
 Multiple methods taken the approach of using a pangenome model to create a single linear sequence that is close to a sample's genome sequence.   
 This sequence can then be used as a reference in conventional variant calling methods. 
 Generally speaking, these methods show improved accuracy over conventional methods alone.
-Gramtools \cite{Maciuca_2016} and PanVC \cite{Valenzuela_2018} both use specialized pangenome indexes to map reads for this purpose.
-PRG uses read $k$-mers from reads to choose paths through a graph to extract as sequences \cite{dilthey2015improved}.
+\textsc{Gramtools} \cite{Maciuca_2016} and \textsc{PanVC} \cite{Valenzuela_2018} both use specialized pangenome indexes to map reads for this purpose.
+\textsc{PRG} uses read $k$-mers from reads to choose paths through a graph to extract as sequences \cite{dilthey2015improved}.
 
 \subsubsection{Small variants}
 
@@ -64,21 +64,21 @@ NGS read lengths are sufficient to span their entirety, and the associated varia
 However, reference bias in mapping can be a source of small variant calling error, and pangenome models provide an opportunity to mitigate these biases.
 
 One strategy for genotyping small variants consists of realigning reads to graphs of known variation after mapping to a linear reference.
-This approach was pioneered in the 1000 Genomes Project by the GLIA software for use on indels and complex regions \cite{1000_2015}.
-More recently, Graphtyper expanded the scale of this approach and incorporated pangenomic data sets.
+This approach was pioneered in the 1000 Genomes Project by the \textsc{GLIA} software for use on indels and complex regions \cite{1000_2015}.
+More recently, \textsc{Graphtyper} expanded the scale of this approach and incorporated pangenomic data sets.
 It has competitive accuracy with state-of-the-art conventional pipelines but better computational efficiency, and incorporating known variation modestly improves its accuracy \cite{eggertsson2017graphtyper}.
 
 Another set of pangenomic variant callers are based on colored de Bruijn graphs.
-Cortex first developed this approach \cite{Iqbal_2012}.
-Cortex calls variants based on coverage in bubble structures in a colored de Bruijn graph, which is constructed from multiple read sets and/or reference genomes.
+\textsc{Cortex} first developed this approach \cite{Iqbal_2012}.
+\textsc{Cortex} calls variants based on coverage in bubble structures in a colored de Bruijn graph, which is constructed from multiple read sets and/or reference genomes.
 This approach permits both pangenomic and reference-free variant calling.
 %constructs a colored de Bruijn graph which can include data of multiple samples and additional sources of sequence information, like a reference genome or known alleles. 
 %Variants are detected by identifying bubble structures in the graph and  genotyped based on the samples' coverage of allele specific kmers.
 %The approach efficiently handles simultaneous analysis of multiple genomes and enables accurate variant detection in a reference-free manner.
-Bubbleparse extended the Cortex's model to improve SNP discovery \cite{Leggett_2013}.
+\textsc{Bubbleparse} extended the \textsc{Cortex}'s model to improve SNP discovery \cite{Leggett_2013}.
 %Candidate variants are produced by a bubble calling algorithm and a heuristic is presented which uses a classification and ranking system to controls the specificity of reported SNP calls \cite{Leggett_2013}.
 
-Seven Bridges' Graph Genome Pipeline includes a variant calling module that itself is minimally pangenomic beyond its use of graph-based read mappings.
+Seven Bridges' \textsc{Graph Genome Pipeline} includes a variant calling module that itself is minimally pangenomic beyond its use of graph-based read mappings.
 Rather, it is broadly similar to existing local assembly methods based on the linear reference \cite{Poplin_2017, Rimmer_2014} except in that it prioritizes haplotypes that are found in a genome graph \cite{Rakocevic_2019}.
 %This can be seen as an example of a statistical prior on variation expressed in the pangenome; simply knowing where one should look for variants is informative.
 It shows advantages over conventional pipelines in variant recall, especially for indels.
@@ -102,11 +102,11 @@ Some pangenomic genotyping tools have specifically targeted these regions.
 
 Much of this research has focused on the human leukocyte antigen (HLA) genes.
 These medically important immune-related genes are under strong selection for diversity.
-HLA*PRG \cite{dilthey2018hla}, its optimized successor HLA*LA \cite{dilthey2019hla}, Kourami \cite{lee2018kourami}, and HISAT-genotype \cite{Kim_2019} have all demonstrated techniques for genotyping HLA genes by aligning NGS reads to a graph encoding various HLA alleles.
+\textsc{HLA*PRG} \cite{dilthey2018hla}, its optimized successor \textsc{HLA*LA} \cite{dilthey2019hla}, \textsc{Kourami} \cite{lee2018kourami}, and \textsc{HISAT-genotype} \cite{Kim_2019} have all demonstrated techniques for genotyping HLA genes by aligning NGS reads to a graph encoding various HLA alleles.
 Their results rival gold-standard Sanger sequencing methods in accuracy.
 Short tandem repeats (STRs) have been another target.
 Their high diversity is driven by high mutation rates, and the low-complexity sequence adds further difficulty.
-ExpansionHunter \cite{dolzhenko2019expansionhunter} and HISAT-genotype \cite{Kim_2019} used similar methodologies to those employed in HLA to achieve comparable or better accuracy than existing methods for STRs.
+\textsc{ExpansionHunter} \cite{dolzhenko2019expansionhunter} and \textsc{HISAT-genotype} \cite{Kim_2019} used similar methodologies to those employed in HLA to achieve comparable or better accuracy than existing methods for STRs.
 %%These genes are critical components of the immune system, which produces a strong selective pressure for diversity and many dramatically distinct alleles.
 %%Determining an individual's HLA alleles is often of great medical importance.
 %
@@ -156,12 +156,12 @@ SVs are difficult to call with NGS reads because they are large relative to the 
 Long read sequencing does not share this difficulty, but this technology remains prohibitively expensive for population-scale studies or routine use.
 This represents an opportunity for pangenomic methods, which can represent SVs naturally represented in genome graphs.
 
-Bayestyper \cite{sibbesen2018accurate} compares the distribution of $k$-mers from sequencing reads to the distribution of $k$-mers along paths in the graph.
+\textsc{Bayestyper} \cite{sibbesen2018accurate} compares the distribution of $k$-mers from sequencing reads to the distribution of $k$-mers along paths in the graph.
 It calls structural variants with high accuracy almost irrespective of the size of the variant.
 However, it has a high memory footprint, and later analysis has also suggested that its reliance on long exact matches makes it fragile to breakpoint uncertainty \cite{hickey2019genotyping}.
 
-In constrast, Paragraph \cite{chen2019paragraph} and VG's genotyper \cite{hickey2019genotyping} are both based on aligning reads to graphs.
-The largest difference is that Paragraph maps to a linear reference and then realigns to local graphs (much like Graphtyper \cite{eggertsson2017graphtyper}), whereas VG maps reads directly to a graph.
+In constrast, \textsc{Paragraph} \cite{chen2019paragraph} and \textsc{VG}'s genotyper \cite{hickey2019genotyping} are both based on aligning reads to graphs.
+The largest difference is that \textsc{Paragraph} maps to a linear reference and then realigns to local graphs (much like \textsc{Graphtyper} \cite{eggertsson2017graphtyper}), whereas VG maps reads directly to a graph.
 Both methods use read coverage to determine the genotype.
 Further, both methods were shown to significantly outperform similar methods based on the linear reference.
 
@@ -184,7 +184,7 @@ Further, both methods were shown to significantly outperform similar methods bas
 Determining the two genome sequences of diploid organisms per chromosome is important in order to correctly understand allele-specific expression and compound heterozygosity, and in order to carry out many analyses in the genetics of common diseases and in population genetics \cite{tewhey2011importance}. 
 However, current assembly approaches often generate mixed haplotype assembly and, therefore, fail to capture the diploid nature of the organism under study. 
 
-WHdenovo \cite{garg2019trio, garg2018graph} is the first tool that leverages information of short and long-reads to generate happlotype-resolved assembly. 
+\textsc{WHdenovo} \cite{garg2019trio, garg2018graph} is the first tool that leverages information of short and long-reads to generate happlotype-resolved assembly. 
 The basic idea is to work in the space of assembly graph (without collapses halotypes) to perform phasing. 
 This method was applied to genomes of moderate sizes with low to high heterozygosity rates. 
 Furthermore, we have shown that we can detect and phase structural variants.
@@ -193,7 +193,7 @@ Furthermore, we have shown that we can detect and phase structural variants.
 % Glenn
 
 CHiP-seq data, reads that bind to specific transcription factors, can be mapped back to the reference genome in order to locate binding sites.
-Graph Peak Caller is based on \texttt{vg} and is the first tool to use a genome graph for this process \cite{Grytten_2019}.
+\textsc{Graph Peak Caller} is based on \texttt{vg} and is the first tool to use a genome graph for this process \cite{Grytten_2019}.
 It was shown to find binding sites more enriched for known DNA binding motifs than linear methods on \emph{A. thaliana}.
 It was also applied to human data to discover novel sites for enhancers in the human genome \cite{groza2019personalized}. 
 
@@ -209,23 +209,23 @@ Using variation information during mapping can help ameliorate this and improve 
 
 The simplest approach to using variation data in mapping involves creating a personalized diploid genome or transcriptome, which is then used as the reference for a standard linear mapping method \cite{Rozowsky_2011,Raghupathy2018-sd}.
 Methods using this approach have been shown to reduce reference bias and improve estimation of ASE, relative to traditional single reference genome methods, but they are generally limited by requiring phased haplotypes of either the whole genome or the individual genes for the individuals under study.
-Variant-aware mappers like GSNAP \cite{Wu2010-hv}, iMapSplice \cite{Liu_2018} and HISAT2 \cite{Kim_2019} remove this necessity.
+Variant-aware mappers like \textsc{GSNAP} \cite{Wu2010-hv}, \textsc{iMapSplice} \cite{Liu_2018} and \textsc{HISAT2} \cite{Kim_2019} remove this necessity.
 Indeed, all three have shown to reduce reference bias by using known SNVs during mapping \cite{Castel2015-ef,Liu_2018}.
-ASElux takes a different approach and only aligns reads that overlaps heterozygous exonic SNVs \cite{Miao2018-ps}.
+\textsc{ASElux} takes a different approach and only aligns reads that overlaps heterozygous exonic SNVs \cite{Miao2018-ps}.
 It create a suffix array index of the alleles and their flanking sequences, which is used to filter reads that do not closely match an allele.
 Allelic read count for each heterozygous SNV is then estimated using alignments of this smaller read set.
-The authors demonstrate that ASElux is able to improve estimation of ASE compared to similar pipelines based on linear mapping methods.
+The authors demonstrate that \textsc{ASElux} is able to improve estimation of ASE compared to similar pipelines based on linear mapping methods.
 
 Variation-aware analysis of RNA-seq data is important for accurately analyzing highly polymorphic regions.
 As with variant calling, the specific region that has generated the most interest is the HLA genes in the human MHC. 
-AltHapAlignR \cite{Lee_2018} and HLApers \cite{Aguiar2019-fy} both compare reads against a collection of known HLA haplotypes rather than the linear reference, and both have demonstrated improved estimation of HLA expression.
+\textsc{AltHapAlignR} \cite{Lee_2018} and \textsc{HLApers} \cite{Aguiar2019-fy} both compare reads against a collection of known HLA haplotypes rather than the linear reference, and both have demonstrated improved estimation of HLA expression.
 
 Even intronic variation can be helpful for analyzing RNA-seq data. 
 Intronic variation can disrupt existing splice-site motifs or create new ones, resulting in intron retention or novel splicing, respectively. 
 Many mappers factor canonical splice-site motifs into alignment scores across splice junctions
 Thus, mappers that are aware of changes to the motifs can give more accurate mapping results on the modified splice-junctions. 
 Indeed, by using a personalized genome approach, \citeauthor{Stein_2015} \cite{Stein_2015} were able to identify 506 personal splice junctions in 75 individuals, of which 437 were novel.
-Even more novel junctions were later found in the same individuals by \citeauthor{Liu_2018} using iMapSplice \cite{Liu_2018}.
+Even more novel junctions were later found in the same individuals by \citeauthor{Liu_2018} using \textsc{iMapSplice} \cite{Liu_2018}.
 
 %ASElux is significantly faster than GSNAP, but GSNAP reduces reference bias slightly more \cite{Miao2018-ps}.
 
@@ -261,10 +261,10 @@ Even more novel junctions were later found in the same individuals by \citeautho
 Most of the methods mentioned in this review has focused on the analyses of human data, however, the benefits of using graphs as a non-linear pangenomic reference structure have also been demonstrated for other species.
 This is especially true for bacterial metagenomics and viral quasispecies where the sequencing data consists of a mixture of closely related sequences (e.g. strains).
 A graph with sequence paths here provides a natural representation of the data and methods have been developed that specifically take advantage of this. 
-Mykrobe predictor \cite{Bradley2015-kl} and GROOT \cite{Rowe2018-bg} uses graph-based structures of bacterial genomes and gene sets to predict antibody resistance in sequencing samples.
-Virus-VG \cite{Baaijens2019-ng} builds a variation graph from assembled viral contigs in order to construct haplotypes and predict associated abundances in viral quasispecies from sequencing reads.
-Their method was later improved in VG-Flow \cite{Baaijens2019-ha} which can scale to much larger genomes, such as bacteria.  
-MetaKallisto \cite{Schaeffer2017-fh} performs taxonomical classification and quantification of metagenomic sequencing data using a database of known sequences represented as colored de Bruijn graphs.
+\textsc{Mykrobe} predictor \cite{Bradley2015-kl} and \textsc{GROOT} \cite{Rowe2018-bg} uses graph-based structures of bacterial genomes and gene sets to predict antibody resistance in sequencing samples.
+\textsc{Virus-VG} \cite{Baaijens2019-ng} builds a variation graph from assembled viral contigs in order to construct haplotypes and predict associated abundances in viral quasispecies from sequencing reads.
+Their method was later improved in \textsc{VG-Flow} \cite{Baaijens2019-ha} which can scale to much larger genomes, such as bacteria.  
+\textsc{MetaKallisto} \cite{Schaeffer2017-fh} performs taxonomical classification and quantification of metagenomic sequencing data using a database of known sequences represented as colored de Bruijn graphs.
 
 %Mykrobe predictor uses reference de Bruijn graphs to estimate antibody resistance from \textit{S. aureus} and \textit{M. Tuberculosis} sequencing data \cite{Bradley2015-kl}.
 %The graphs are constructed from known resistant relevant alleles and genes and compared to a whole-genome de Bruijn graph built from the sample's sequencing reads.

--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -20,12 +20,10 @@ Second, known variation can help applications avoid algorithmic artifacts that f
 %Together, these advantages are helping pangenomics expand the limits of what variation current technology can detect and how accurately it can do so.
 
 In many ways, the spiritual predecessors of pangenomic variant calling are multi-sample calling methods. 
-Many of these were developed alongside major population sequencing projects like the 1000 Genomes Project \cite{1000_2015}.
-They co-call variants on a group of samples in a single, shared inference process.
+These were designed to co-call the samples from major population sequencing projects, like the 1000 Genomes Project \cite{1000_2015}, in a single, shared inference process.
 The motivation for doing so mirrors the motivation for pangenomic variant calling: increased statistical power via a shared prior and reduced algorithmic bias.
-The main difference today is the abundance of data available.
 It is no longer necessary to restrict inference to the samples from one project.
-With public databases of variation, the benefits of multi-sample calling can now be brought to bear even on individual samples.
+With increasingly large public databases of variation, the benefits of multi-sample calling can now be brought to bear even on individual samples.
 
 In pangenomics, it is useful to distinguish between \emph{variant calling} and \emph{genotyping}.
 Genotyping consists of determining whether a previously observed variant is present in a new sample, whereas variant calling involves detecting yet unobserved variation.

--- a/sections/applications.tex
+++ b/sections/applications.tex
@@ -1,12 +1,12 @@
 \section{Applications of pangenomic models}
 
-\subsection{Error correction}
-
-De Bruijn graph based methods have been used for correcting errors in reads.
-The principle used by these methods is to build an assembly from accurate short reads and use that to correct the reads.
-Assembly methods used include de Bruijn graphs \cite{Salmela2014LoRDEC, Salmela2016LORMA}, de Bruijn graphs with various cleaning operations \cite{Miclotte2016Jabba, Limasset_2019, Rautiainen_2019b, Marchet_2019}, FM-index representing all de Bruijn graphs \cite{Wang2018FMLRC} and variable order de Bruijn graphs \cite{Morisse2018HGcolor, Morisse2019Consent}.
-The reads are aligned to the assembly and the path in the graph is extracted as the corrected read.
-Comparisons of error correction methods \cite{Fu2019ErrorCorrectionSurvey, Zhang2019ErrorCorrectionSurvey} have found de Bruijn graph based methods to outperform read alignment based methods.
+%\subsection{Error correction}
+%
+%De Bruijn graph based methods have been used for correcting errors in reads.
+%The principle used by these methods is to build an assembly from accurate short reads and use that to correct the reads.
+%Assembly methods used include de Bruijn graphs \cite{Salmela2014LoRDEC, Salmela2016LORMA}, de Bruijn graphs with various cleaning operations \cite{Miclotte2016Jabba, Limasset_2019, Rautiainen_2019b, Marchet_2019}, FM-index representing all de Bruijn graphs \cite{Wang2018FMLRC} and variable order de Bruijn graphs \cite{Morisse2018HGcolor, Morisse2019Consent}.
+%The reads are aligned to the assembly and the path in the graph is extracted as the corrected read.
+%Comparisons of error correction methods \cite{Fu2019ErrorCorrectionSurvey, Zhang2019ErrorCorrectionSurvey} have found de Bruijn graph based methods to outperform read alignment based methods.
 
 \subsection{Variant calling and genotyping}
 

--- a/sections/discussion.tex
+++ b/sections/discussion.tex
@@ -1,5 +1,15 @@
 \section{Discussion}
 
+
+%JME: following a recommendation from Jonas, I'm leaving this paragraph in discussion for possible inclusion later
+
+%Among the graph mappers for variation graphs, a theme has emerged in their accuracy. 
+%They typically do not improve mapping accuracy over the entire genome compared to state-of-the-art linear mappers. 
+%However, they do significantly improve read mapping accuracy \emph{over variants} \cite{Garrison_2019, Rakocevic_2019, Kim_2019}. 
+%In this, we see a concrete example of pangenomic methods mitigating reference bias. 
+%%The unimproved (and often slightly diminished) performance over the rest of the genome probably indicates a combination of the relative nascency of the graph mapping tools and the burden of more complicated computational heuristics.
+%\todo{JAS: Would the above paragraph fit better in the discussion?}
+
 \begin{comment}
   % figure out how to use this
 In precision medicine, we seek accurate inference of a given patient genome.

--- a/sections/models.tex
+++ b/sections/models.tex
@@ -259,7 +259,7 @@ These indexes first find partial matches between the query string and the indexe
 In the hypertext index \cite{Thachuk_2013}, each node is a separate phrase.
 Queries mapping to a single node or crossing a single edge can be matched efficiently, while finding mappings to complex graph regions can be slow.
 
-\citeauthor{Bowe_2012}\ \cite{Bowe_2012} used techniques similar to GCSA for representing de~Bruijn graphs.
+\citeauthor{Bowe_2012} \cite{Bowe_2012} used techniques similar to GCSA for representing de~Bruijn graphs.
 If the graph transformations used in GCSA construction are stopped after $i$ steps, the resulting graph is equivalent to an order-$2^{i}$ de~Bruijn graph.
 This de~Bruijn graph can be used to approximate the original graph.
 There are no false negatives, but matches longer than $2^{i}$ may be false positives.

--- a/sections/relating.tex
+++ b/sections/relating.tex
@@ -18,22 +18,22 @@ An overview of tools features is given in.
 \todo{JAS: Given that the manuscript is max 25 pages this table seems too big. Could it be compressed or some details removed?}
 \todo{Footnotes in the table do not appear in the output PDF.}
 
-Bandage \cite{Wick_2015}, GfaViz \cite{Gonnella_2018}, SGTK \cite{Kunyavskaya_2018} and AGB \cite{Mikheenko_2019} were designed to explore assembly graphs.
+\textsc{Bandage} \cite{Wick_2015}, \textsc{GfaViz} \cite{Gonnella_2018}, \textsc{SGTK} \cite{Kunyavskaya_2018} and \textsc{AGB} \cite{Mikheenko_2019} were designed to explore assembly graphs.
 Bandage is the oldest and most widely used, supporting a wide range of formats and graph  paradigms, however it does not currently support GFA2 \citep{Mikheenko_2019}.
 Force-directed graph layouts, which use a physics simulation to allow graph elements to lay themselves out in two dimensions, can present a graph in an aesthetically pleasing way, but their reliance on only local information in the layout process can make displaying annotations challenging.
-For this reason, SGTK and AGB offer a more traditional genome browser mode as well.
-Except for GfaViz, they do not have the ability to structure the display using known linearization information. 
+For this reason, \textsc{SGTK} and \textsc{AGB} offer a more traditional genome browser mode as well.
+Except for \textsc{GfaViz}, they do not have the ability to structure the display using known linearization information. 
 
 %When choosing a tool, one also must consider the advantages of web applications versus local computation.  
 %Web apps have the option to serve precomputed content to any user, lowering end-user system requirements.
 %Local applications can benefit from institution specific resources including HPC and private data (see Table \ref{table:Visualization_Features} Technical Notes).
 
-For variation graphs, Sequence Tube Map \cite{Beyer_2019} displays regions using a visual language inspired by transit system maps.
+For variation graphs, \textsc{Sequence Tube Map} \cite{Beyer_2019} displays regions using a visual language inspired by transit system maps.
 This tool is useful for visualizing precise base-scale variation and short read mapping locations in human-chromosome-scale graphs.
 However, its limited graph simplification tools make it difficult to use on larger regions.
 
 There is a difference in scale when moving from an assembly or scaffold graph to a comprehensive variation graph of a species pangenome.
-While tools like SGTK and AGB have been demonstrated on graphs with tens of thousands of entities, the 1000 Genomes Project dataset contains 88 million known human variants \citep{1000_2015}, which induce a comprehensive variation graph of tens to hundreds of millions of elements---a much larger graph than those that SGTK and AGB have been shown to work with.
+While tools like \textsc{SGTK} and \textsc{AGB} have been demonstrated on graphs with tens of thousands of entities, the 1000 Genomes Project dataset contains 88 million known human variants \citep{1000_2015}, which induce a comprehensive variation graph of tens to hundreds of millions of elements---a much larger graph than those that SGTK and AGB have been shown to work with.
 %a density over the 3 billion base human genome of about 34 bases per variant, and
 Moreover, to achieve visualization output file sizes on the scale of megabytes given hundred megabase- to gigabase-scale assemblies, these tools necessarily hide sequence information.
 
@@ -48,15 +48,15 @@ Moreover, to achieve visualization output file sizes on the scale of megabytes g
 %It is relatively tightly tied to the assembly graph use case, requiring each (sequence-bearing) edge to be classifiable as ``unique'' or ``repetitive'' based on assembler annotation or sequencing coverage \citep{Mikheenko_2019}.
 %AGB is built around the idea of splitting up an assembly graph and visualizing portions of it, and features many ways to do this, including linear reference based and minimum edge cut based approaches.
 
-MoMI-G is a multi-scale genome graph browser currently under development \cite{yokoyama_momi-g:_2019}. 
-It employs Sequence Tube Map at nucleotide scale and integrates it into a framework along side a Circos \cite{Krzywinski_2009_Circos} plot for chromosome scale connections. 
+\textsc{MoMI-G} is a multi-scale genome graph browser currently under development \cite{yokoyama_momi-g:_2019}. 
+It employs \textsc{Sequence Tube Map} at nucleotide scale and integrates it into a framework along side a \textsc{Circos} \cite{Krzywinski_2009_Circos} plot for chromosome scale connections. 
 The integration of multiple visualizations brings their strengths to bear on different areas. 
-MoMI-G is currently the only tool that can visualize long reads to show structural variants against multiple haplotypes in a graph genome.
+\textsc{MoMI-G} is currently the only tool that can visualize long reads to show structural variants against multiple haplotypes in a graph genome.
 
-\texttt{vg viz} can render graphs of arbitrary size and complexity in linear time by sorting the sequence-bearing nodes of the graph into a one-dimensional layout \citep{Garrison_2019}. 
+\textsc{vg viz} can render graphs of arbitrary size and complexity in linear time by sorting the sequence-bearing nodes of the graph into a one-dimensional layout \citep{Garrison_2019}. 
 The tool is designed around a base-level visual representation of the graph, and optimized for comparing long embedded paths in the graph, on the basis of which nodes they do or do not visit. 
 It can be difficult to understand high level or nonlinear structures in such a linearized layout. 
-\texttt{ODGI viz}\footnote{\url{https://github.com/vgteam/odgi}} uses a layout very similar to \texttt{vg viz} and addresses scalability by binning hundreds of adjacent nodes together, thus reducing the resolution and making it possible to render the overall structure of gigabase pangenomes in a single image.
+\textsc{odgi viz}\footnote{\url{https://github.com/vgteam/odgi}} uses a layout very similar to \textsc{vg viz} and addresses scalability by binning hundreds of adjacent nodes together, thus reducing the resolution and making it possible to render the overall structure of gigabase pangenomes in a single image.
 
 Figure~\ref{fig:visualization} provides a visual overview of some notable visualization methods, while Table~\ref{table:Visualization_Features} compares these and some additional methods on criteria including layout approach and implementation scalability.
 It remains an open problem to interactively visualize a comprehensive human pangenome graph, potentially including interchromosomal connections, at a variety of zoom levels to enable precision pangenomics at any scale.
@@ -140,30 +140,30 @@ As this description suggests, a mapping tool's features are in large part determ
 
 One major point of distinction between mapping tools is the type of graphs they were designed for. 
 Several tools apply only to acyclic variation graphs formed by adding variants to a linear reference.
-Examples include GenomeMapper (an early forerunner) \cite{Schneeberger_2009}, Seven Bridge's Graph Genome Aligner \cite{Rakocevic_2019}, HISAT2 \cite{Kim_2019}, V-MAP \cite{Vaddadi_2019}.
+Examples include \textsc{GenomeMapper} (an early forerunner) \cite{Schneeberger_2009}, Seven Bridge's \textsc{Graph Genome Aligner} \cite{Rakocevic_2019}, \textsc{HISAT2} \cite{Kim_2019}, \textsc{V-MAP} \cite{Vaddadi_2019}.
 %Another set of tools target DBGs: BGREAT \cite{Limasset_2016}, deBGA \cite{Liu_2016}, and BrownieAligner \cite{Heydari_2018}.
 %These were developed in parallel to recent pangenomics research with motivations in genome assembly. 
-VG \cite{Garrison_2019} and GraphAligner \cite{Rautiainen_2019b} appear to be the only tools with open ambitions of mapping to arbitrary variation graphs, including complex local and global topologies.
-GraphAligner can also align to generic overlap graphs and DBGs.
+\textsc{VG} \cite{Garrison_2019} and \textsc{GraphAligner} \cite{Rautiainen_2019b} appear to be the only tools with open ambitions of mapping to arbitrary variation graphs, including complex local and global topologies.
+\textsc{GraphAligner} can also align to generic overlap graphs and DBGs.
 This gives it a second role in a related literature of mapping to DBGs for genome assembly and error correction \cite{Heydari_2018, Fu2019ErrorCorrectionSurvey}.
 
 The majority of these tools emphasize mapping short-read \emph{next-generation sequencing (NGS)} data. 
 %Most likely, the motivation for doing so is the same as why NGS remains the standard for conventional resequencing experiments; the price point currently favors it. 
 %In this sense, pangenomic graph mappers essentially represent an incremental technical improvement over previous pipelines, albeit a very important one. 
-To our knowledge, GraphAligner and V-MAP are the only graph mapping tools that explicitly targets long read sequencing data \cite{Rautiainen_2019b, Vaddadi_2019}.
-V-MAP is also demonstrated on NGS reads, but GraphAligner's seeding strategy limits it to long reads.
+To our knowledge, \textsc{GraphAligner} and \textsc{V-MAP} are the only graph mapping tools that explicitly targets long read sequencing data \cite{Rautiainen_2019b, Vaddadi_2019}.
+\textsc{V-MAP} is also demonstrated on NGS reads, but \textsc{GraphAligner}'s seeding strategy limits it to long reads.
 
 The actual algorithms that each tool employs vary greatly. 
 For indexing, most graph mapping tools have opted for some variation of a $k$-mer table. 
 %In the case of DBG mappers, this is an especially attractive option since the $k$-mers also implicitly define the edges of the graph. 
 %This may be why 
 %In fact, all of the DBG mappers listed above use this strategy \cite{Holley_2012, Limasset_2016, Liu_2016, Heydari_2018, Rautiainen_2019b}. 
-Additionally, GraphAligner, GenomeMapper, Seven Bridge's mapper, and V-MAP seed with $k$-mer tables \cite{Rautiainen_2019b, Schneeberger_2009, Rakocevic_2019, Vaddadi_2019}. 
+\textsc{GraphAligner}, \textsc{GenomeMapper}, Seven Bridge's mapper, and \textsc{V-MAP} all use this strategy \cite{Rautiainen_2019b, Schneeberger_2009, Rakocevic_2019, Vaddadi_2019}. 
 The remaining mappers use succinct text indexes.
-VG uses the GCSA2 \cite{Siren_2017} and a longest-common-prefix array, which enable very specific queries at the expense of high memory utilization \cite{Garrison_2019}.
-HISAT2 uses a modified GCSA \cite{Siren_2014} that also encodes the graph structure itself.
-This helps give HISAT2 an impressively low memory footprint but a somewhat more limited set of queries \cite{Kim_2019}.
-GraphAligner also has the option of seeding with a full text index of the node sequences of the graph, but the memory savings of its indexes are offset by data structures that support its alignment algorithm \cite{Rautiainen_2019b}.
+\textsc{VG} uses the GCSA2 \cite{Siren_2017} and a longest-common-prefix array, which enable very specific queries at the expense of high memory utilization \cite{Garrison_2019}.
+\textsc{HISAT2} uses a modified GCSA \cite{Siren_2014} that also encodes the graph structure itself.
+This helps give \textsc{HISAT2} an impressively low memory footprint but a somewhat more limited set of queries \cite{Kim_2019}.
+\textsc{GraphAligner} also has the option of seeding with a full text index of the node sequences of the graph, but the memory savings of its indexes are offset by data structures that support its alignment algorithm \cite{Rautiainen_2019b}.
 
 %Most DBG mappers have used searches through the graph to make alignments.
 %deBGA and BrownieAligner exhaustively enumerate paths from seeds. 
@@ -178,19 +178,19 @@ GraphAligner also has the option of seeding with a full text index of the node s
 %According to the authors' analysis, BrownieAligner is more accurate than deBGA and BGREAT, but BGREAT tends to be more memory efficient, and deBGA tends to be faster \cite{Heydari_2018}.
 
 
-While few of the DBG mappers employ graph-based alignment algorithms, most variation graph mappers do. 
-The exceptions are GenomeMapper, which aligns to all paths out from a seed, and HISAT2.
-The HISAT2 alignment algorithm is a complex set of heuristics that lean heavily on its optimized exact match index.  
+The majority of graph mappers employ graph-based alignment algorithms. 
+The exceptions are \textsc{GenomeMapper}, which aligns to all paths out from a seed, and \textsc{HISAT2}.
+The \textsc{HISAT2} alignment algorithm is a complex set of heuristics that lean heavily on its optimized exact match index.  
 This makes it exceptionally fast, although it also can hurt alignment quality around indels. 
 %However, GenomeMapper also seems to be unmaintained since 2009, and its heuristics appear better suited to earlier NGS technologies \cite{Schneeberger_2009}. 
-Seven Bridges' mapper, VG, and V-MAP all employ some version of partial order alignment \cite{Rakocevic_2019, Garrison_2019, Vaddadi_2019}. 
+Seven Bridges' mapper, \textsc{VG}, and \textsc{V-MAP} all employ some version of partial order alignment \cite{Rakocevic_2019, Garrison_2019, Vaddadi_2019}. 
 %Seven Bridges also tries to find a near-match using a potentially exponential depth-first search algorithm before resorting to alignment algorithms that are more expensive when variation is sparse \cite{Rakocevic_2019}. 
 %The HISAT2 alignment algorithm is a complex set of heuristics that lean heavily on its optimized exact match index. 
-In general, VG compares favorably to other tools in terms of accuracy on NGS data. 
+In general, \textsc{VG} compares favorably to other tools in terms of accuracy on NGS data. 
 However, most comparisons point out that it is quite demanding on computer memory and often slower than the alternatives \cite{Kim_2019, Vaddadi_2019}. 
 %V-MAP uses distance-based heuristics on acyclic graphs to efficiently cluster seeds. 
-V-MAP's fast clustering heuristics allow it to align long reads faster than VG, but there is no published comparison to GraphAligner \cite{Vaddadi_2019}.
-GraphAligner is the only mapper to incorporate the most recent research into graph alignment algorithms.
+\textsc{V-MAP}'s fast clustering heuristics allow it to align long reads faster than \textsc{VG}, but there is no published comparison to \textsc{GraphAligner} \cite{Vaddadi_2019}.
+\textsc{GraphAligner} is the only mapper to incorporate the most recent research into graph alignment algorithms.
 It uses a banded alignment algorithm to achieve impressive speed aligning long reads to genome graphs \cite{Rautiainen_2019b}.
 %\todo{JAS: Are the last two paragraph too detailed? Could they be shorten? The whole mapping section seems a bit long compared to some of the other sections.}
 \todo{JAS: In table 2 only VG is described as accurate. Is that true and what is meant by accurate? I think it could be misunderstood. \\ JME: I agree. I'm not quite sure what level of detail we should leave in the table now that we're removing detail from the text.}
@@ -422,20 +422,20 @@ Due to the presence of splicing, mapping transcriptomic reads typically requires
 Thus, variation and splicing-aware mappers for transcriptomic reads have largely been developed in parallel to mappers for genomic reads, although graphical methods have recently created some room for overlap.
 
 Several methods have been published that specifically focus on reducing mapping bias for RNA-seq data around SNVs. 
-GSNAP was the first such method \cite{Wu2010-hv}.
+\textsc{GSNAP} was the first such method \cite{Wu2010-hv}.
 It seeds mappings with a hash table of $k$-mers from both the genome and a set of SNVs.
 The current version uses a suffix array as well. 
-Similar, iMapSplice creates an enhanced suffix array of a set of SNV alleles and their flanking sequences \cite{Liu_2018}.
+Similar, \textsc{iMapSplice} creates an enhanced suffix array of a set of SNV alleles and their flanking sequences \cite{Liu_2018}.
 The reads are then mapped to the SNV index and the reference genome allowing for spliced alignments.
 Both methods, however, only support SNVs and are therefore unable to reduce reference bias around indels.
 
 In contrast, graph-based methods can easily model indels.
-HISAT2 can map RNA-seq data in addition to genomic DNA \cite{Kim_2019}.
-It is based on the RNA mapper HISAT \cite{Kim_2015}, and it retains the capacity for spliced alignment.
+\textsc{HISAT2} can map RNA-seq data in addition to genomic DNA \cite{Kim_2019}.
+It is based on the RNA mapper \textsc{HISAT} \cite{Kim_2015}, and it retains the capacity for spliced alignment.
 Otherwise, its mapping algorithm for transcriptomic sequencing is the same as for genomic DNA (See above).
 The ability to create spliced variation graphs has also been added to VG \cite{Garrison_2018}. 
 In these variation graphs, known splice junctions are added as edges, similar to the addition of a deletion event.
-VG supports any type of variation, but its splicing-awareness is limited to only known splice junctions.
+\textsc{VG} supports any type of variation, but its splicing-awareness is limited to only known splice junctions.
 Thus, reads that span a novel splice junction will only map partially.
 
 

--- a/sections/relating.tex
+++ b/sections/relating.tex
@@ -141,10 +141,11 @@ As this description suggests, a mapping tool's features are in large part determ
 One major point of distinction between mapping tools is the type of graphs they were designed for. 
 Several tools apply only to acyclic variation graphs formed by adding variants to a linear reference.
 Examples include GenomeMapper (an early forerunner) \cite{Schneeberger_2009}, Seven Bridge's Graph Genome Aligner \cite{Rakocevic_2019}, HISAT2 \cite{Kim_2019}, V-MAP \cite{Vaddadi_2019}.
-Another set of tools target DBGs: BGREAT \cite{Limasset_2016}, deBGA \cite{Liu_2016}, and BrownieAligner \cite{Heydari_2018}.
-These were developed in parallel to recent pangenomics research with motivations in genome assembly. 
+%Another set of tools target DBGs: BGREAT \cite{Limasset_2016}, deBGA \cite{Liu_2016}, and BrownieAligner \cite{Heydari_2018}.
+%These were developed in parallel to recent pangenomics research with motivations in genome assembly. 
 VG \cite{Garrison_2019} and GraphAligner \cite{Rautiainen_2019b} appear to be the only tools with open ambitions of mapping to arbitrary variation graphs, including complex local and global topologies.
-Notably, GraphAligner can also align to generic overlap graphs and DBGs.
+GraphAligner can also align to generic overlap graphs and DBGs.
+This gives it a second role in a related literature of mapping to DBGs for genome assembly and error correction \cite{Heydari_2018, Fu2019ErrorCorrectionSurvey}.
 
 The majority of these tools emphasize mapping short-read \emph{next-generation sequencing (NGS)} data. 
 %Most likely, the motivation for doing so is the same as why NGS remains the standard for conventional resequencing experiments; the price point currently favors it. 
@@ -152,40 +153,30 @@ The majority of these tools emphasize mapping short-read \emph{next-generation s
 To our knowledge, GraphAligner and V-MAP are the only graph mapping tools that explicitly targets long read sequencing data \cite{Rautiainen_2019b, Vaddadi_2019}.
 V-MAP is also demonstrated on NGS reads, but GraphAligner's seeding strategy limits it to long reads.
 
-% a paragraph about the approximations used?
-
-Among the graph mappers for variation graphs, a theme has emerged in their accuracy. 
-They typically do not improve mapping accuracy over the entire genome compared to state-of-the-art linear mappers. 
-However, they do significantly improve read mapping accuracy \emph{over variants} \cite{Garrison_2019, Rakocevic_2019, Kim_2019}. 
-In this, we see a concrete example of pangenomic methods mitigating reference bias. 
-%The unimproved (and often slightly diminished) performance over the rest of the genome probably indicates a combination of the relative nascency of the graph mapping tools and the burden of more complicated computational heuristics.
-\todo{JAS: Would the above paragraph fit better in the discussion?}
-
 The actual algorithms that each tool employs vary greatly. 
 For indexing, most graph mapping tools have opted for some variation of a $k$-mer table. 
 %In the case of DBG mappers, this is an especially attractive option since the $k$-mers also implicitly define the edges of the graph. 
 %This may be why 
-In fact, all of the DBG mappers listed above use this strategy \cite{Holley_2012, Limasset_2016, Liu_2016, Heydari_2018, Rautiainen_2019b}. 
-Additionally, GenomeMapper, Seven Bridge's mapper, and V-MAP seed with $k$-mer tables \cite{Schneeberger_2009, Rakocevic_2019, Vaddadi_2019}. 
+%In fact, all of the DBG mappers listed above use this strategy \cite{Holley_2012, Limasset_2016, Liu_2016, Heydari_2018, Rautiainen_2019b}. 
+Additionally, GraphAligner, GenomeMapper, Seven Bridge's mapper, and V-MAP seed with $k$-mer tables \cite{Rautiainen_2019b, Schneeberger_2009, Rakocevic_2019, Vaddadi_2019}. 
 The remaining mappers use succinct text indexes.
 VG uses the GCSA2 \cite{Siren_2017} and a longest-common-prefix array, which enable very specific queries at the expense of high memory utilization \cite{Garrison_2019}.
 HISAT2 uses a modified GCSA \cite{Siren_2014} that also encodes the graph structure itself.
 This helps give HISAT2 an impressively low memory footprint but a somewhat more limited set of queries \cite{Kim_2019}.
 GraphAligner also has the option of seeding with a full text index of the node sequences of the graph, but the memory savings of its indexes are offset by data structures that support its alignment algorithm \cite{Rautiainen_2019b}.
 
-Most DBG mappers have used searches through the graph to make alignments.
-deBGA and BrownieAligner exhaustively enumerate paths from seeds. 
-BrownieAligner limits the potentially exponential space using branch-and-bound, whereas deBGA uses a clustering step \cite{Liu_2016, Heydari_2018}.
-%Its core alignment algorithm is actually a sequence-to-sequence algorithm applied to each path \cite{Liu_2016}.
-BGREAT addresses the combinatorial complexity of the extension step by greedily choosing a path in the graph \cite{Limasset_2016}.
-%This is fast but non-optimal, and their algorithm does not support indels \cite{Limasset_2016}.
-%Unfortunately, neither deBGA nor BGREAT compare their performance to any graph-based tools, and the unintended context for the linear mappers they compare to makes their evaluations hard to interpret.
-%BrownieAligner also exhaustively explores paths out from a seed, but it uses a branch-and-bound algorithm to prune the search space along the way.
-%It also has a unique trick of choosing paths partially based on a Markov model trained on the reads.
-%This is essentially a limited form of read-backed phasing.
-According to the authors' analysis, BrownieAligner is more accurate than deBGA and BGREAT, but BGREAT tends to be more memory efficient, and deBGA tends to be faster \cite{Heydari_2018}.
-GraphAligner is the only DBG mapper to incorporate recent research into graph alignment algorithms.
-It uses a banded alignment algorithm to achieve impressive speed aligning long reads to genome graphs \cite{Rautiainen_2019b}.
+%Most DBG mappers have used searches through the graph to make alignments.
+%deBGA and BrownieAligner exhaustively enumerate paths from seeds. 
+%BrownieAligner limits the potentially exponential space using branch-and-bound, whereas deBGA uses a clustering step \cite{Liu_2016, Heydari_2018}.
+%%Its core alignment algorithm is actually a sequence-to-sequence algorithm applied to each path \cite{Liu_2016}.
+%BGREAT addresses the combinatorial complexity of the extension step by greedily choosing a path in the graph \cite{Limasset_2016}.
+%%This is fast but non-optimal, and their algorithm does not support indels \cite{Limasset_2016}.
+%%Unfortunately, neither deBGA nor BGREAT compare their performance to any graph-based tools, and the unintended context for the linear mappers they compare to makes their evaluations hard to interpret.
+%%BrownieAligner also exhaustively explores paths out from a seed, but it uses a branch-and-bound algorithm to prune the search space along the way.
+%%It also has a unique trick of choosing paths partially based on a Markov model trained on the reads.
+%%This is essentially a limited form of read-backed phasing.
+%According to the authors' analysis, BrownieAligner is more accurate than deBGA and BGREAT, but BGREAT tends to be more memory efficient, and deBGA tends to be faster \cite{Heydari_2018}.
+
 
 While few of the DBG mappers employ graph-based alignment algorithms, most variation graph mappers do. 
 The exceptions are GenomeMapper, which aligns to all paths out from a seed, and HISAT2.
@@ -199,6 +190,8 @@ In general, VG compares favorably to other tools in terms of accuracy on NGS dat
 However, most comparisons point out that it is quite demanding on computer memory and often slower than the alternatives \cite{Kim_2019, Vaddadi_2019}. 
 %V-MAP uses distance-based heuristics on acyclic graphs to efficiently cluster seeds. 
 V-MAP's fast clustering heuristics allow it to align long reads faster than VG, but there is no published comparison to GraphAligner \cite{Vaddadi_2019}.
+GraphAligner is the only mapper to incorporate the most recent research into graph alignment algorithms.
+It uses a banded alignment algorithm to achieve impressive speed aligning long reads to genome graphs \cite{Rautiainen_2019b}.
 %\todo{JAS: Are the last two paragraph too detailed? Could they be shorten? The whole mapping section seems a bit long compared to some of the other sections.}
 \todo{JAS: In table 2 only VG is described as accurate. Is that true and what is meant by accurate? I think it could be misunderstood. \\ JME: I agree. I'm not quite sure what level of detail we should leave in the table now that we're removing detail from the text.}
 

--- a/sections/relating.tex
+++ b/sections/relating.tex
@@ -184,8 +184,7 @@ The \textsc{HISAT2} alignment algorithm is a complex set of heuristics that lean
 This makes it exceptionally fast, although it also can hurt alignment quality around indels. 
 %However, GenomeMapper also seems to be unmaintained since 2009, and its heuristics appear better suited to earlier NGS technologies \cite{Schneeberger_2009}. 
 Seven Bridges' mapper, \textsc{VG}, and \textsc{V-MAP} all employ some version of partial order alignment \cite{Rakocevic_2019, Garrison_2019, Vaddadi_2019}. 
-%Seven Bridges also tries to find a near-match using a potentially exponential depth-first search algorithm before resorting to alignment algorithms that are more expensive when variation is sparse \cite{Rakocevic_2019}. 
-%The HISAT2 alignment algorithm is a complex set of heuristics that lean heavily on its optimized exact match index. 
+Seven Bridges also tries to find a near-match using a potentially exponential depth-first search algorithm before resorting to alignment \cite{Rakocevic_2019}. 
 In general, \textsc{VG} compares favorably to other tools in terms of accuracy on NGS data. 
 However, most comparisons point out that it is quite demanding on computer memory and often slower than the alternatives \cite{Kim_2019, Vaddadi_2019}. 
 %V-MAP uses distance-based heuristics on acyclic graphs to efficiently cluster seeds. 
@@ -425,7 +424,7 @@ Several methods have been published that specifically focus on reducing mapping 
 \textsc{GSNAP} was the first such method \cite{Wu2010-hv}.
 It seeds mappings with a hash table of $k$-mers from both the genome and a set of SNVs.
 The current version uses a suffix array as well. 
-Similar, \textsc{iMapSplice} creates an enhanced suffix array of a set of SNV alleles and their flanking sequences \cite{Liu_2018}.
+Similarly, \textsc{iMapSplice} creates an enhanced suffix array of a set of SNV alleles and their flanking sequences \cite{Liu_2018}.
 The reads are then mapped to the SNV index and the reference genome allowing for spliced alignments.
 Both methods, however, only support SNVs and are therefore unable to reduce reference bias around indels.
 
@@ -435,8 +434,8 @@ It is based on the RNA mapper \textsc{HISAT} \cite{Kim_2015}, and it retains the
 Otherwise, its mapping algorithm for transcriptomic sequencing is the same as for genomic DNA (See above).
 The ability to create spliced variation graphs has also been added to VG \cite{Garrison_2018}. 
 In these variation graphs, known splice junctions are added as edges, similar to the addition of a deletion event.
-\textsc{VG} supports any type of variation, but its splicing-awareness is limited to only known splice junctions.
-Thus, reads that span a novel splice junction will only map partially.
+\textsc{VG} supports any type of variation, but its splicing-awareness is limited to known splice junctions.
+%Thus, reads that span a novel splice junction will only map partially.
 
 
 %Proper variant-aware mapping methods, on the other hand, do not require that the variants are phased beforehand.


### PR DESCRIPTION
I cut the error correction section on account of it not really being a pangenomic method per se (or at least not necessarily). That brought us down quite a few refs. I also removed the de Bruijn graph mappers, with the exception of GraphAligner, and I emphasized GraphAligner's mapping to general graphs rather than to de Bruijn graphs. I also started switching over to \textsc for tool names.

Let me know if anyone strongly disagrees with these changes.