### PR TITLE
correct GFAv1 link

### DIFF
--- a/sections/models.tex
+++ b/sections/models.tex
@@ -28,7 +28,7 @@ Paths provide a stable coordinate system that is unaffected by the manner in whi
 A number of common data formats are used to exchange pangenomic models.
 Pangenomes can be stored as collections of sequences in FASTA format.
 Variant calls in VCF format may be added to such a collection to describe small or structural variants found in the pangenome.
-However, to exchange graphical pangenomes, the community frequently uses a subset of the GFAv1\footnote{\url{http://gfa-spec.github.io/GFA-spec/}} assembly graph format.
+However, to exchange graphical pangenomes, the community frequently uses a subset of the GFAv1\footnote{\url{https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md}} assembly graph format.
 This has the benefit of allowing the application of tools that read GFA to pangenome graphs.
 
 GFA provides no mechanism to express read alignments.


### PR DESCRIPTION
The footnote of `GFAv1` was pointing to the wrong URL.